### PR TITLE
Update target framework for test project to be non-EOL version

### DIFF
--- a/NServiceBus.NewRelic.Analyzer/NServiceBus.NewRelic.Analyzer.Test/NServiceBus.NewRelic.Analyzer.Test.csproj
+++ b/NServiceBus.NewRelic.Analyzer/NServiceBus.NewRelic.Analyzer.Test/NServiceBus.NewRelic.Analyzer.Test.csproj
@@ -1,10 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
netcoreapp2.0 is EOL so retargeting to netcoreapp3.1.  I Attempted to try net5.0 but the nuget package containing the msbuild task for il-repack is not fuly compatible
